### PR TITLE
Change use of ascii to broad utf-8

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -264,8 +264,8 @@ class GraphAPI(object):
                 L.append('Content-Disposition: form-data; name="%s"' % key)
             L.append('')
             if isinstance(value, unicode):
-                logging.debug("Convert to ascii")
-                value = value.encode('ascii')
+                logging.debug("Convert to utf-8")
+                value = value.encode('utf-8')
             L.append(value)
         L.append('--' + BOUNDARY + '--')
         L.append('')


### PR DESCRIPTION
#### Bug

when calling the `put_photo` method with non ascii char in the message (french, spanish or russian message) this broke.

ex:
```
message = u'été à Paris'
api = facebook.GraphAPI(access_token)
api.put_photo(image, message, album_id)
```

leads to a `UnicodeEncodeError: 'ascii' codec can't encode character ...`

#### to test

try the above code with a valid access_token/album_id/image