### PR TITLE
appengine example now uses new database library ndb instead of db

### DIFF
--- a/examples/appengine/example.py
+++ b/examples/appengine/example.py
@@ -43,13 +43,13 @@ config = {}
 config['webapp2_extras.sessions'] = dict(secret_key='')
 
 
-class User(db.Model):
-    id = db.StringProperty(required=True)
-    created = db.DateTimeProperty(auto_now_add=True)
-    updated = db.DateTimeProperty(auto_now=True)
-    name = db.StringProperty(required=True)
-    profile_url = db.StringProperty(required=True)
-    access_token = db.StringProperty(required=True)
+class User(ndb.Model):
+    id = ndb.StringProperty(required=True)
+    created = ndb.DateTimeProperty(auto_now_add=True)
+    updated = ndb.DateTimeProperty(auto_now=True)
+    name = ndb.StringProperty(required=True)
+    profile_url = ndb.StringProperty(required=True)
+    access_token = ndb.StringProperty(required=True)
 
 
 class BaseHandler(webapp2.RequestHandler):
@@ -74,13 +74,12 @@ class BaseHandler(webapp2.RequestHandler):
             if cookie:
                 # Okay so user logged in.
                 # Now, check to see if existing user
-                user = User.get_by_key_name(cookie["uid"])
+                user = User.query(User.id==cookie["uid"]).get()
                 if not user:
                     # Not an existing user so get user info
                     graph = facebook.GraphAPI(cookie["access_token"])
                     profile = graph.get_object("me")
                     user = User(
-                        key_name=str(profile["id"]),
                         id=str(profile["id"]),
                         name=profile["name"],
                         profile_url=profile["link"],


### PR DESCRIPTION
It's unclear whether ndb Entity id correspond to the db Entity key name or not, docs are not clear about it (https://developers.google.com/appengine/docs/python/ndb/modelclass#Constructor). I've tried different solutions but 

- define id property and query with id as argument works
- NOT define id property and query with id as argument NOT works
- define id property and use get_by_id for retriving entity NOT works

Anyhow for changing least as possible I retained the id name and adopted the first from previous solutions. 


