### PR TITLE
correct endpoint for extending short-lived access tokens + unit test

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -279,7 +279,7 @@ class GraphAPI(object):
             "fb_exchange_token": self.access_token,
         }
 
-        return self.request("access_token", args=args)
+        return self.request("oauth/access_token", args=args)
 
 
 class GraphAPIError(Exception):

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -41,6 +41,19 @@ class TestGetAppAccessToken(FacebookTestCase):
         token = facebook.get_app_access_token(self.app_id, self.secret)
         assert(isinstance(token, str) or isinstance(token, unicode))
 
+class TestExtendAccessToken(FacebookTestCase):
+    """
+    Test if extend_access_token requests the correct endpoint.
+
+    Note that this only tests whether extend_access_token returns the correct 
+    error message when called without a proper user-access token.
+    """
+    def test_extend_access_token(self):    
+        try:
+            facebook.extend_access_token(self.app_id, self.secret)
+        except facebook.GraphAPIError, e:
+            assert e.message == 'No user access token specified'
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
See #127.  Without a user access token in the test environment it is difficult to write a proper unit test.  This test only checks whether the endpoint returns the expected error message.