### PR TITLE
Allow passing integers to get_connections

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -100,7 +100,7 @@ class GraphAPI(object):
 
     def get_connections(self, id, connection_name, **args):
         """Fetchs the connections for given object."""
-        return self.request(id + "/" + connection_name, args)
+        return self.request("%s/%s" % (id, connection_name), args)
 
     def put_object(self, parent_object, connection_name, **data):
         """Writes the given object to the graph, connected to the given parent.


### PR DESCRIPTION
This is an improvement to remove an operand type clash that occurs if you pass in a string and number to self.request