### PR TITLE
Rename id param in get_object() to object_id

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -105,9 +105,9 @@ class GraphAPI(object):
         else:
             self.version = "v" + default_version
 
-    def get_object(self, id, **args):
+    def get_object(self, object_id, **args):
         """Fetchs the given object from the graph."""
-        return self.request(self.version + "/" + id, args)
+        return self.request(self.version + "/" + object_id, args)
 
     def get_objects(self, ids, **args):
         """Fetchs all of the given object from the graph.


### PR DESCRIPTION
In order to specify 'id' as a keyword argument,
we cannot use 'id' as a positional argument name.