### PR TITLE
enabling API v2.3 support and adding equivalent test case

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -85,7 +85,7 @@ class GraphAPI(object):
     def __init__(self, access_token=None, timeout=None, version=None):
         # The default version is only used if the version kwarg does not exist.
         default_version = "1.0"
-        valid_API_versions = ["1.0", "2.0", "2.1", "2.2"]
+        valid_API_versions = ["1.0", "2.0", "2.1", "2.2", "2.3"]
 
         self.access_token = access_token
         self.timeout = timeout

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -74,6 +74,10 @@ class TestAPIVersion(FacebookTestCase):
         graph = facebook.GraphAPI(version=2.2)
         self.assertEqual(graph.get_version(), 2.2)
 
+    def test_version_2_3(self):
+        graph = facebook.GraphAPI(version=2.3)
+        self.assertEqual(graph.get_version(), 2.3)
+
     def test_invalid_version(self):
         self.assertRaises(facebook.GraphAPIError,
                           facebook.GraphAPI, version=1.2)


### PR DESCRIPTION
F8 began today. I noticed a new API version being released. Since the API changes are mostly in permissions and most calls are the same, I think this would be sufficient enough for typical usage of v2.3. 