### PR TITLE
Add support for appsecret_proof

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -82,12 +82,20 @@ class GraphAPI(object):
 
     """
 
-    def __init__(self, access_token=None, timeout=None, version=None):
+    def __init__(self, access_token=None, appsecret=None, timeout=None, version=None):
         # The default version is only used if the version kwarg does not exist.
         default_version = "2.0"
         valid_API_versions = ["2.0", "2.1", "2.2", "2.3"]
 
         self.access_token = access_token
+        if appsecret:
+            # https://developers.facebook.com/docs/graph-api/securing-requests#appsecret_proof
+            appsecret_hmac = hmac.new(appsecret.encode('ascii'), msg=access_token.encode('ascii'),
+                                      digestmod=hashlib.sha256)
+            self.appsecret_proof = appsecret_hmac.hexdigest()
+        else:
+            self.appsecret_proof = None
+            
         self.timeout = timeout
 
         if version:
@@ -241,6 +249,9 @@ class GraphAPI(object):
                 post_args["access_token"] = self.access_token
             else:
                 args["access_token"] = self.access_token
+        
+        if self.appsecret_proof:
+            args["appsecret_proof"] = self.appsecret_proof
 
         try:
             response = requests.request(method or "GET",


### PR DESCRIPTION
With this change, you are able to create graph API on apps that have `App Secret Only` enabled. Basically, that's a feature that only allows requests that send the appsecret (good for servers). 

You can read about it here: https://developers.facebook.com/docs/graph-api/securing-requests#appsecret_proof

This implementation works, and the documentation should just say:
> GraphAPI(access_token=None, **appsecret**=None, timeout=None, version=None)

> appsecret: The `App Secret key` of the app using the Graph. This is usable for apps that only allow requests from server. Read more: https://developers.facebook.com/docs/facebook-login/security#appsecret